### PR TITLE
Added makeliinks.sh

### DIFF
--- a/makelinks.sh
+++ b/makelinks.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ln -sv ../lib/extension.js ./Chrome/extension.js
+ln -sv ../../lib/extension.js ./Opera/includes/extension.user.js
+ln -sv ../../lib/extension.js ./Firefox/data/extension.js
+ln -v ./lib/extension.js ./Safari.safariextension/extension.js 
+
+ln -sv ../lib/BabelExt.js ./Chrome/BabelExt.js
+ln -sv ../../lib/BabelExt.js ./Opera/includes/BabelExt.js
+ln -sv ../../lib/BabelExt.js ./Firefox/data/BabelExt.js
+ln -v ./lib/BabelExt.js ./Safari.safariextension/BabelExt.js


### PR DESCRIPTION
This will create the symbolic and hard links BabelExt requires on Linux.  (Not tested, but it should work on OS X, as well.)
